### PR TITLE
Bump to Alpine 3.15 and PowerDNS 4.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15 as base
 
-ENV REFRESHED_AT="2022-12-20" \
-    POWERDNS_VERSION="4.7.0" \
+ENV REFRESHED_AT="2024-01-05" \
+    POWERDNS_VERSION="4.7.4" \
     BUILD_DEPS="g++ make mariadb-dev postgresql-dev sqlite-dev curl boost-dev mariadb-connector-c-dev" \
     RUN_DEPS="bash libpq sqlite-libs libstdc++ libgcc mariadb-client postgresql-client sqlite mariadb-connector-c lua-dev curl-dev boost-program_options" \
     POWERDNS_MODULES="bind gmysql gpgsql gsqlite3"
@@ -37,15 +37,15 @@ ENV AUTOCONF=mysql \
     MYSQL_PASS="root" \
     MYSQL_DB="pdns" \
     MYSQL_DNSSEC="no" \
-    MYSQL_VERSION="4.3.0" \
+    MYSQL_VERSION="4.7.0" \
     PGSQL_HOST="postgres" \
     PGSQL_PORT="5432" \
     PGSQL_USER="postgres" \
     PGSQL_PASS="postgres" \
     PGSQL_DB="pdns" \
-    PGSQL_VERSION="4.3.0" \
+    PGSQL_VERSION="4.7.0" \
     SQLITE_DB="pdns.sqlite3" \
-    SQLITE_VERSION="4.3.1" \
+    SQLITE_VERSION="4.7.0" \
     SCHEMA_VERSION_TABLE="_schema_version"
 
 EXPOSE 53/tcp 53/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.9 as base
+FROM alpine:3.15 as base
 
-ENV REFRESHED_AT="2019-10-10" \
-    POWERDNS_VERSION="4.3.1" \
+ENV REFRESHED_AT="2022-03-04" \
+    POWERDNS_VERSION="4.6.0" \
     BUILD_DEPS="g++ make mariadb-dev postgresql-dev sqlite-dev curl boost-dev mariadb-connector-c-dev" \
     RUN_DEPS="bash libpq sqlite-libs libstdc++ libgcc mariadb-client postgresql-client sqlite mariadb-connector-c lua-dev curl-dev boost-program_options" \
     POWERDNS_MODULES="bind gmysql gpgsql gsqlite3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15 as base
 
-ENV REFRESHED_AT="2022-03-04" \
-    POWERDNS_VERSION="4.6.0" \
+ENV REFRESHED_AT="2022-12-20" \
+    POWERDNS_VERSION="4.7.0" \
     BUILD_DEPS="g++ make mariadb-dev postgresql-dev sqlite-dev curl boost-dev mariadb-connector-c-dev" \
     RUN_DEPS="bash libpq sqlite-libs libstdc++ libgcc mariadb-client postgresql-client sqlite mariadb-connector-c lua-dev curl-dev boost-program_options" \
     POWERDNS_MODULES="bind gmysql gpgsql gsqlite3"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - psql_volume:/var/lib/postgresql
 
   pdns_mysql:
-    image: naps/powerdns
+    build: ../
     environment:
       AUTOCONF: mysql
       MYSQL_HOST: mysql
@@ -27,7 +27,7 @@ services:
       - --allow-axfr-ips=127.0.0.1,123.1.2.3
 
   pdns_psql:
-    image: naps/powerdns
+    build: ../
     environment:
       AUTOCONF: postgres
       PGSQL_HOST: psql
@@ -38,7 +38,7 @@ services:
       - --allow-axfr-ips=127.0.0.1,123.1.2.3
 
   pdns_sqlite:
-    image: naps/powerdns
+    build: ../
     environment:
       AUTOCONF: sqlite
       SQLITE_DB: /data/db.sqlite


### PR DESCRIPTION
Bumping up version of base alpine image and to most recent powerdns release.

I checked and there does not seem to be any new sql schema changes for mysql, postgres, and sqlite.